### PR TITLE
Fix coverage stats in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           AAS_CORE_3_0_GOLANG_TEST_DATA_DIR: ${{ github.workspace }}/testdata
         run: |
-          go test -covermode atomic -coverprofile=covprofile ./...
+          go test -covermode atomic -coverpkg=./... -coverprofile=covprofile ./...
 
       - name: Send coverage
         env:


### PR DESCRIPTION
The stats reported to coveralls.io were wrong as we did not specify the coverpkg option.