### PR TITLE
Add general XML unmarshalling

### DIFF
--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/observableReference.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/observableReference.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+: The required property 'observableReference' is missing

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/source.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/source.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+: The required property 'source' is missing

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/timeStamp.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/RequiredViolation/EventPayload/timeStamp.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+: The required property 'timeStamp' is missing

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+observableReference: Expected a sequence of XML elements representing properties of IReference, but got text: Unexpected string value

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+observableSemanticId: Expected a sequence of XML elements representing properties of IReference, but got text: Unexpected string value

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/payload.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/payload.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+payload: Text could not be decoded as base64: illegal base64 data at input byte 1

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/source.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/source.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+source: Expected a sequence of XML elements representing properties of IReference, but got text: Unexpected string value

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+sourceSemanticId: Expected a sequence of XML elements representing properties of IReference, but got text: Unexpected string value

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+subjectId: Expected a sequence of XML elements representing properties of IReference, but got text: Unexpected string value

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+: Expected an end element timeStamp, but got a start element reference in namespace https://admin-shell.io/aas/3/0

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/topic.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/TypeViolation/EventPayload/topic.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+: Expected an end element topic, but got a start element reference in namespace https://admin-shell.io/aas/3/0

--- a/testdata/DeserializationError/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/EventPayload/invalid.xml.error
+++ b/testdata/DeserializationError/Xml/SelfContained/Unexpected/UnexpectedAdditionalProperty/EventPayload/invalid.xml.error
@@ -1,1 +1,1 @@
-: Expected a start element with local name environment, but got a start element with local name eventPayload
+unexpectedAdditionalProperty: Unexpected property

--- a/xmlization/test/generated_of_concrete_classes_test.go
+++ b/xmlization/test/generated_of_concrete_classes_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	aastesting "github.com/aas-core-works/aas-core3.0-golang/aastesting"
+	aastypes "github.com/aas-core-works/aas-core3.0-golang/types"
 	aasxmlization "github.com/aas-core-works/aas-core3.0-golang/xmlization"
 	"os"
 	"path/filepath"
@@ -40,9 +41,18 @@ func TestExtensionRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -112,7 +122,7 @@ func TestExtensionDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -146,9 +156,18 @@ func TestAdministrativeInformationRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -218,7 +237,7 @@ func TestAdministrativeInformationDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -252,9 +271,18 @@ func TestQualifierRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -324,7 +352,7 @@ func TestQualifierDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -358,9 +386,18 @@ func TestAssetAdministrationShellRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -430,7 +467,7 @@ func TestAssetAdministrationShellDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -464,9 +501,18 @@ func TestAssetInformationRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -536,7 +582,7 @@ func TestAssetInformationDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -570,9 +616,18 @@ func TestResourceRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -642,7 +697,7 @@ func TestResourceDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -676,9 +731,18 @@ func TestSpecificAssetIDRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -748,7 +812,7 @@ func TestSpecificAssetIDDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -782,9 +846,18 @@ func TestSubmodelRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -854,7 +927,7 @@ func TestSubmodelDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -888,9 +961,18 @@ func TestRelationshipElementRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -960,7 +1042,7 @@ func TestRelationshipElementDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -994,9 +1076,18 @@ func TestSubmodelElementListRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1066,7 +1157,7 @@ func TestSubmodelElementListDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1100,9 +1191,18 @@ func TestSubmodelElementCollectionRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1172,7 +1272,7 @@ func TestSubmodelElementCollectionDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1206,9 +1306,18 @@ func TestPropertyRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1278,7 +1387,7 @@ func TestPropertyDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1312,9 +1421,18 @@ func TestMultiLanguagePropertyRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1384,7 +1502,7 @@ func TestMultiLanguagePropertyDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1418,9 +1536,18 @@ func TestRangeRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1490,7 +1617,7 @@ func TestRangeDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1524,9 +1651,18 @@ func TestReferenceElementRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1596,7 +1732,7 @@ func TestReferenceElementDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1630,9 +1766,18 @@ func TestBlobRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1702,7 +1847,7 @@ func TestBlobDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1736,9 +1881,18 @@ func TestFileRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1808,7 +1962,7 @@ func TestFileDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1842,9 +1996,18 @@ func TestAnnotatedRelationshipElementRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -1914,7 +2077,7 @@ func TestAnnotatedRelationshipElementDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -1948,9 +2111,18 @@ func TestEntityRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2020,7 +2192,7 @@ func TestEntityDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2054,9 +2226,18 @@ func TestEventPayloadRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEventPayload(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEventPayload); !ok {
+			t.Fatalf(
+				"Expected an instance of IEventPayload, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2126,7 +2307,7 @@ func TestEventPayloadDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2160,9 +2341,18 @@ func TestBasicEventElementRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2232,7 +2422,7 @@ func TestBasicEventElementDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2266,9 +2456,18 @@ func TestOperationRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2338,7 +2537,7 @@ func TestOperationDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2372,9 +2571,18 @@ func TestOperationVariableRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2444,7 +2652,7 @@ func TestOperationVariableDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2478,9 +2686,18 @@ func TestCapabilityRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2550,7 +2767,7 @@ func TestCapabilityDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2584,9 +2801,18 @@ func TestConceptDescriptionRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2656,7 +2882,7 @@ func TestConceptDescriptionDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2690,9 +2916,18 @@ func TestReferenceRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2762,7 +2997,7 @@ func TestReferenceDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2796,9 +3031,18 @@ func TestKeyRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2868,7 +3112,7 @@ func TestKeyDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -2902,9 +3146,18 @@ func TestLangStringNameTypeRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -2974,7 +3227,7 @@ func TestLangStringNameTypeDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3008,9 +3261,18 @@ func TestLangStringTextTypeRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3080,7 +3342,7 @@ func TestLangStringTextTypeDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3114,9 +3376,18 @@ func TestEnvironmentRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3186,7 +3457,7 @@ func TestEnvironmentDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3220,9 +3491,18 @@ func TestEmbeddedDataSpecificationRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3292,7 +3572,7 @@ func TestEmbeddedDataSpecificationDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3326,9 +3606,18 @@ func TestLevelTypeRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3398,7 +3687,7 @@ func TestLevelTypeDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3432,9 +3721,18 @@ func TestValueReferencePairRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3504,7 +3802,7 @@ func TestValueReferencePairDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3538,9 +3836,18 @@ func TestValueListRoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3610,7 +3917,7 @@ func TestValueListDeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3644,9 +3951,18 @@ func TestLangStringPreferredNameTypeIEC61360RoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3716,7 +4032,7 @@ func TestLangStringPreferredNameTypeIEC61360DeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3750,9 +4066,18 @@ func TestLangStringShortNameTypeIEC61360RoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3822,7 +4147,7 @@ func TestLangStringShortNameTypeIEC61360DeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3856,9 +4181,18 @@ func TestLangStringDefinitionTypeIEC61360RoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -3928,7 +4262,7 @@ func TestLangStringDefinitionTypeIEC61360DeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)
@@ -3962,9 +4296,18 @@ func TestDataSpecificationIEC61360RoundTripOK(t *testing.T) {
 
 		decoder := xml.NewDecoder(strings.NewReader(text))
 
-		deserialized, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+		deserialized, deseriaErr := aasxmlization.Unmarshal(decoder)
 		ok := assertNoDeserializationError(t, deseriaErr, pth)
 		if !ok {
+			return
+		}
+
+		if _, ok := deserialized.(aastypes.IEnvironment); !ok {
+			t.Fatalf(
+				"Expected an instance of IEnvironment, "+
+					"but got %T: %v",
+				deserialized, deserialized,
+			)
 			return
 		}
 
@@ -4034,7 +4377,7 @@ func TestDataSpecificationIEC61360DeserializationFail(t *testing.T) {
 
 			decoder := xml.NewDecoder(strings.NewReader(text))
 
-			_, deseriaErr := aasxmlization.UnmarshalEnvironment(decoder)
+			_, deseriaErr := aasxmlization.Unmarshal(decoder)
 			ok := assertIsDeserializationErrorAndEqualsExpectedOrRecord(
 				t, deseriaErr, pth, expectedPth,
 			)

--- a/xmlization/xmlization.go
+++ b/xmlization/xmlization.go
@@ -685,7 +685,7 @@ func readHasSemanticsWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalHasSemantics(
+func unmarshalHasSemantics(
 	decoder *xml.Decoder,
 ) (instance aastypes.IHasSemantics,
 	err error,
@@ -941,7 +941,7 @@ func readExtensionWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalExtension(
+func unmarshalExtension(
 	decoder *xml.Decoder,
 ) (instance aastypes.IExtension,
 	err error,
@@ -1083,7 +1083,7 @@ func readHasExtensionsWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalHasExtensions(
+func unmarshalHasExtensions(
 	decoder *xml.Decoder,
 ) (instance aastypes.IHasExtensions,
 	err error,
@@ -1225,7 +1225,7 @@ func readReferableWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalReferable(
+func unmarshalReferable(
 	decoder *xml.Decoder,
 ) (instance aastypes.IReferable,
 	err error,
@@ -1311,7 +1311,7 @@ func readIdentifiableWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalIdentifiable(
+func unmarshalIdentifiable(
 	decoder *xml.Decoder,
 ) (instance aastypes.IIdentifiable,
 	err error,
@@ -1426,7 +1426,7 @@ func readHasKindWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalHasKind(
+func unmarshalHasKind(
 	decoder *xml.Decoder,
 ) (instance aastypes.IHasKind,
 	err error,
@@ -1572,7 +1572,7 @@ func readHasDataSpecificationWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalHasDataSpecification(
+func unmarshalHasDataSpecification(
 	decoder *xml.Decoder,
 ) (instance aastypes.IHasDataSpecification,
 	err error,
@@ -1810,7 +1810,7 @@ func readAdministrativeInformationWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalAdministrativeInformation(
+func unmarshalAdministrativeInformation(
 	decoder *xml.Decoder,
 ) (instance aastypes.IAdministrativeInformation,
 	err error,
@@ -1944,7 +1944,7 @@ func readQualifiableWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalQualifiable(
+func unmarshalQualifiable(
 	decoder *xml.Decoder,
 ) (instance aastypes.IQualifiable,
 	err error,
@@ -2253,7 +2253,7 @@ func readQualifierWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalQualifier(
+func unmarshalQualifier(
 	decoder *xml.Decoder,
 ) (instance aastypes.IQualifier,
 	err error,
@@ -2569,7 +2569,7 @@ func readAssetAdministrationShellWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalAssetAdministrationShell(
+func unmarshalAssetAdministrationShell(
 	decoder *xml.Decoder,
 ) (instance aastypes.IAssetAdministrationShell,
 	err error,
@@ -2814,7 +2814,7 @@ func readAssetInformationWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalAssetInformation(
+func unmarshalAssetInformation(
 	decoder *xml.Decoder,
 ) (instance aastypes.IAssetInformation,
 	err error,
@@ -3026,7 +3026,7 @@ func readResourceWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalResource(
+func unmarshalResource(
 	decoder *xml.Decoder,
 ) (instance aastypes.IResource,
 	err error,
@@ -3311,7 +3311,7 @@ func readSpecificAssetIDWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalSpecificAssetID(
+func unmarshalSpecificAssetID(
 	decoder *xml.Decoder,
 ) (instance aastypes.ISpecificAssetID,
 	err error,
@@ -3644,7 +3644,7 @@ func readSubmodelWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalSubmodel(
+func unmarshalSubmodel(
 	decoder *xml.Decoder,
 ) (instance aastypes.ISubmodel,
 	err error,
@@ -3774,7 +3774,7 @@ func readSubmodelElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalSubmodelElement(
+func unmarshalSubmodelElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.ISubmodelElement,
 	err error,
@@ -4094,7 +4094,7 @@ func readRelationshipElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalRelationshipElement(
+func unmarshalRelationshipElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IRelationshipElement,
 	err error,
@@ -4476,7 +4476,7 @@ func readSubmodelElementListWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalSubmodelElementList(
+func unmarshalSubmodelElementList(
 	decoder *xml.Decoder,
 ) (instance aastypes.ISubmodelElementList,
 	err error,
@@ -4768,7 +4768,7 @@ func readSubmodelElementCollectionWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalSubmodelElementCollection(
+func unmarshalSubmodelElementCollection(
 	decoder *xml.Decoder,
 ) (instance aastypes.ISubmodelElementCollection,
 	err error,
@@ -4866,7 +4866,7 @@ func readDataElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalDataElement(
+func unmarshalDataElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IDataElement,
 	err error,
@@ -5188,7 +5188,7 @@ func readPropertyWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalProperty(
+func unmarshalProperty(
 	decoder *xml.Decoder,
 ) (instance aastypes.IProperty,
 	err error,
@@ -5490,7 +5490,7 @@ func readMultiLanguagePropertyWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalMultiLanguageProperty(
+func unmarshalMultiLanguageProperty(
 	decoder *xml.Decoder,
 ) (instance aastypes.IMultiLanguageProperty,
 	err error,
@@ -5814,7 +5814,7 @@ func readRangeWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalRange(
+func unmarshalRange(
 	decoder *xml.Decoder,
 ) (instance aastypes.IRange,
 	err error,
@@ -6105,7 +6105,7 @@ func readReferenceElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalReferenceElement(
+func unmarshalReferenceElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IReferenceElement,
 	err error,
@@ -6415,7 +6415,7 @@ func readBlobWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalBlob(
+func unmarshalBlob(
 	decoder *xml.Decoder,
 ) (instance aastypes.IBlob,
 	err error,
@@ -6727,7 +6727,7 @@ func readFileWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalFile(
+func unmarshalFile(
 	decoder *xml.Decoder,
 ) (instance aastypes.IFile,
 	err error,
@@ -7055,7 +7055,7 @@ func readAnnotatedRelationshipElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalAnnotatedRelationshipElement(
+func unmarshalAnnotatedRelationshipElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IAnnotatedRelationshipElement,
 	err error,
@@ -7389,7 +7389,7 @@ func readEntityWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalEntity(
+func unmarshalEntity(
 	decoder *xml.Decoder,
 ) (instance aastypes.IEntity,
 	err error,
@@ -7786,7 +7786,7 @@ func readEventPayloadWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalEventPayload(
+func unmarshalEventPayload(
 	decoder *xml.Decoder,
 ) (instance aastypes.IEventPayload,
 	err error,
@@ -7864,7 +7864,7 @@ func readEventElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalEventElement(
+func unmarshalEventElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IEventElement,
 	err error,
@@ -8256,7 +8256,7 @@ func readBasicEventElementWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalBasicEventElement(
+func unmarshalBasicEventElement(
 	decoder *xml.Decoder,
 ) (instance aastypes.IBasicEventElement,
 	err error,
@@ -8570,7 +8570,7 @@ func readOperationWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalOperation(
+func unmarshalOperation(
 	decoder *xml.Decoder,
 ) (instance aastypes.IOperation,
 	err error,
@@ -8650,10 +8650,10 @@ func readOperationVariableAsSequence(
 		var valueErr error
 		switch local {
 		case "value":
-			theValue, valueErr = UnmarshalSubmodelElement(
+			theValue, valueErr = unmarshalSubmodelElement(
 				decoder,
 			)
-			// UnmarshalSubmodelElement stops at the end element,
+			// unmarshalSubmodelElement stops at the end element,
 			// so we look ahead to the next element.
 			if valueErr == nil {
 				current, valueErr = readNext(decoder, current)
@@ -8774,7 +8774,7 @@ func readOperationVariableWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalOperationVariable(
+func unmarshalOperationVariable(
 	decoder *xml.Decoder,
 ) (instance aastypes.IOperationVariable,
 	err error,
@@ -9055,7 +9055,7 @@ func readCapabilityWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalCapability(
+func unmarshalCapability(
 	decoder *xml.Decoder,
 ) (instance aastypes.ICapability,
 	err error,
@@ -9344,7 +9344,7 @@ func readConceptDescriptionWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalConceptDescription(
+func unmarshalConceptDescription(
 	decoder *xml.Decoder,
 ) (instance aastypes.IConceptDescription,
 	err error,
@@ -9609,7 +9609,7 @@ func readReferenceWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalReference(
+func unmarshalReference(
 	decoder *xml.Decoder,
 ) (instance aastypes.IReference,
 	err error,
@@ -9826,7 +9826,7 @@ func readKeyWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalKey(
+func unmarshalKey(
 	decoder *xml.Decoder,
 ) (instance aastypes.IKey,
 	err error,
@@ -9994,7 +9994,7 @@ func readAbstractLangStringWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalAbstractLangString(
+func unmarshalAbstractLangString(
 	decoder *xml.Decoder,
 ) (instance aastypes.IAbstractLangString,
 	err error,
@@ -10211,7 +10211,7 @@ func readLangStringNameTypeWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLangStringNameType(
+func unmarshalLangStringNameType(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILangStringNameType,
 	err error,
@@ -10428,7 +10428,7 @@ func readLangStringTextTypeWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLangStringTextType(
+func unmarshalLangStringTextType(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILangStringTextType,
 	err error,
@@ -10642,7 +10642,7 @@ func readEnvironmentWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalEnvironment(
+func unmarshalEnvironment(
 	decoder *xml.Decoder,
 ) (instance aastypes.IEnvironment,
 	err error,
@@ -10720,7 +10720,7 @@ func readDataSpecificationContentWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalDataSpecificationContent(
+func unmarshalDataSpecificationContent(
 	decoder *xml.Decoder,
 ) (instance aastypes.IDataSpecificationContent,
 	err error,
@@ -10809,10 +10809,10 @@ func readEmbeddedDataSpecificationAsSequence(
 			foundDataSpecification = true
 
 		case "dataSpecificationContent":
-			theDataSpecificationContent, valueErr = UnmarshalDataSpecificationContent(
+			theDataSpecificationContent, valueErr = unmarshalDataSpecificationContent(
 				decoder,
 			)
-			// UnmarshalDataSpecificationContent stops at the end element,
+			// unmarshalDataSpecificationContent stops at the end element,
 			// so we look ahead to the next element.
 			if valueErr == nil {
 				current, valueErr = readNext(decoder, current)
@@ -10941,7 +10941,7 @@ func readEmbeddedDataSpecificationWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalEmbeddedDataSpecification(
+func unmarshalEmbeddedDataSpecification(
 	decoder *xml.Decoder,
 ) (instance aastypes.IEmbeddedDataSpecification,
 	err error,
@@ -11229,7 +11229,7 @@ func readLevelTypeWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLevelType(
+func unmarshalLevelType(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILevelType,
 	err error,
@@ -11446,7 +11446,7 @@ func readValueReferencePairWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalValueReferencePair(
+func unmarshalValueReferencePair(
 	decoder *xml.Decoder,
 ) (instance aastypes.IValueReferencePair,
 	err error,
@@ -11647,7 +11647,7 @@ func readValueListWithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalValueList(
+func unmarshalValueList(
 	decoder *xml.Decoder,
 ) (instance aastypes.IValueList,
 	err error,
@@ -11864,7 +11864,7 @@ func readLangStringPreferredNameTypeIEC61360WithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLangStringPreferredNameTypeIEC61360(
+func unmarshalLangStringPreferredNameTypeIEC61360(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILangStringPreferredNameTypeIEC61360,
 	err error,
@@ -12081,7 +12081,7 @@ func readLangStringShortNameTypeIEC61360WithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLangStringShortNameTypeIEC61360(
+func unmarshalLangStringShortNameTypeIEC61360(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILangStringShortNameTypeIEC61360,
 	err error,
@@ -12298,7 +12298,7 @@ func readLangStringDefinitionTypeIEC61360WithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalLangStringDefinitionTypeIEC61360(
+func unmarshalLangStringDefinitionTypeIEC61360(
 	decoder *xml.Decoder,
 ) (instance aastypes.ILangStringDefinitionTypeIEC61360,
 	err error,
@@ -12623,7 +12623,7 @@ func readDataSpecificationIEC61360WithLookahead(
 // serialized as an XML element.
 //
 // The XML element must live in the [Namespace] space.
-func UnmarshalDataSpecificationIEC61360(
+func unmarshalDataSpecificationIEC61360(
 	decoder *xml.Decoder,
 ) (instance aastypes.IDataSpecificationIEC61360,
 	err error,
@@ -12642,6 +12642,206 @@ func UnmarshalDataSpecificationIEC61360(
 		decoder,
 		current,
 	)
+	return
+}
+
+// Unmarshal an instance of [aastypes.IClass] serialized as an XML element.
+//
+// The XML element must live in the [Namespace] space.
+func Unmarshal(
+	decoder *xml.Decoder,
+) (instance aastypes.IClass, err error) {
+	var current xml.Token
+	current, err = readNext(decoder, nil)
+	if err != nil {
+		return
+	}
+
+	current, err = skipEmptyTextWhitespaceAndComments(decoder, current)
+	if err != nil {
+		return
+	}
+
+	var local string
+	local, err = parseAsStartElementAndExtractLocalName(
+		current,
+	)
+	if err != nil {
+		return
+	}
+
+	// Move the current to the properties of the instance
+	current, err = readNext(decoder, current)
+	if err != nil {
+		return
+	}
+
+	switch local {
+	case "extension":
+		instance, current, err = readExtensionAsSequence(
+			decoder, current,
+		)
+	case "administrativeInformation":
+		instance, current, err = readAdministrativeInformationAsSequence(
+			decoder, current,
+		)
+	case "qualifier":
+		instance, current, err = readQualifierAsSequence(
+			decoder, current,
+		)
+	case "assetAdministrationShell":
+		instance, current, err = readAssetAdministrationShellAsSequence(
+			decoder, current,
+		)
+	case "assetInformation":
+		instance, current, err = readAssetInformationAsSequence(
+			decoder, current,
+		)
+	case "resource":
+		instance, current, err = readResourceAsSequence(
+			decoder, current,
+		)
+	case "specificAssetId":
+		instance, current, err = readSpecificAssetIDAsSequence(
+			decoder, current,
+		)
+	case "submodel":
+		instance, current, err = readSubmodelAsSequence(
+			decoder, current,
+		)
+	case "relationshipElement":
+		instance, current, err = readRelationshipElementAsSequence(
+			decoder, current,
+		)
+	case "submodelElementList":
+		instance, current, err = readSubmodelElementListAsSequence(
+			decoder, current,
+		)
+	case "submodelElementCollection":
+		instance, current, err = readSubmodelElementCollectionAsSequence(
+			decoder, current,
+		)
+	case "property":
+		instance, current, err = readPropertyAsSequence(
+			decoder, current,
+		)
+	case "multiLanguageProperty":
+		instance, current, err = readMultiLanguagePropertyAsSequence(
+			decoder, current,
+		)
+	case "range":
+		instance, current, err = readRangeAsSequence(
+			decoder, current,
+		)
+	case "referenceElement":
+		instance, current, err = readReferenceElementAsSequence(
+			decoder, current,
+		)
+	case "blob":
+		instance, current, err = readBlobAsSequence(
+			decoder, current,
+		)
+	case "file":
+		instance, current, err = readFileAsSequence(
+			decoder, current,
+		)
+	case "annotatedRelationshipElement":
+		instance, current, err = readAnnotatedRelationshipElementAsSequence(
+			decoder, current,
+		)
+	case "entity":
+		instance, current, err = readEntityAsSequence(
+			decoder, current,
+		)
+	case "eventPayload":
+		instance, current, err = readEventPayloadAsSequence(
+			decoder, current,
+		)
+	case "basicEventElement":
+		instance, current, err = readBasicEventElementAsSequence(
+			decoder, current,
+		)
+	case "operation":
+		instance, current, err = readOperationAsSequence(
+			decoder, current,
+		)
+	case "operationVariable":
+		instance, current, err = readOperationVariableAsSequence(
+			decoder, current,
+		)
+	case "capability":
+		instance, current, err = readCapabilityAsSequence(
+			decoder, current,
+		)
+	case "conceptDescription":
+		instance, current, err = readConceptDescriptionAsSequence(
+			decoder, current,
+		)
+	case "reference":
+		instance, current, err = readReferenceAsSequence(
+			decoder, current,
+		)
+	case "key":
+		instance, current, err = readKeyAsSequence(
+			decoder, current,
+		)
+	case "langStringNameType":
+		instance, current, err = readLangStringNameTypeAsSequence(
+			decoder, current,
+		)
+	case "langStringTextType":
+		instance, current, err = readLangStringTextTypeAsSequence(
+			decoder, current,
+		)
+	case "environment":
+		instance, current, err = readEnvironmentAsSequence(
+			decoder, current,
+		)
+	case "embeddedDataSpecification":
+		instance, current, err = readEmbeddedDataSpecificationAsSequence(
+			decoder, current,
+		)
+	case "levelType":
+		instance, current, err = readLevelTypeAsSequence(
+			decoder, current,
+		)
+	case "valueReferencePair":
+		instance, current, err = readValueReferencePairAsSequence(
+			decoder, current,
+		)
+	case "valueList":
+		instance, current, err = readValueListAsSequence(
+			decoder, current,
+		)
+	case "langStringPreferredNameTypeIec61360":
+		instance, current, err = readLangStringPreferredNameTypeIEC61360AsSequence(
+			decoder, current,
+		)
+	case "langStringShortNameTypeIec61360":
+		instance, current, err = readLangStringShortNameTypeIEC61360AsSequence(
+			decoder, current,
+		)
+	case "langStringDefinitionTypeIec61360":
+		instance, current, err = readLangStringDefinitionTypeIEC61360AsSequence(
+			decoder, current,
+		)
+	case "dataSpecificationIec61360":
+		instance, current, err = readDataSpecificationIEC61360AsSequence(
+			decoder, current,
+		)
+	default:
+		err = newDeserializationError(
+			fmt.Sprintf(
+				"Unexpected XML element name %s as class discriminator",
+				local,
+			),
+		)
+	}
+	if err != nil {
+		return
+	}
+
+	err = checkEndElement(current, local)
 	return
 }
 


### PR DESCRIPTION
We add a function `Unmarshal` to `xmlization` which infers the model type from the XML. This frees the user to know the model type ahead of the time.