### PR TITLE
Update to aas-core-meta, codegen, testgen 44756fb, 607f65c, bf3720d7

### DIFF
--- a/_dev_scripts/aas_core3/__init__.py
+++ b/_dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a8a510e
+The revision of aas-core-codegen was: 607f65c
 """

--- a/_dev_scripts/aas_core3/types.py
+++ b/_dev_scripts/aas_core3/types.py
@@ -680,10 +680,6 @@ class Qualifiable(Class):
     The value of a qualifiable element may be further qualified by one or more
     qualifiers.
 
-    .. note::
-
-        This constraint is checked at :py:class:`Submodel`.
-
     :constraint AASd-119:
         .. _constraint_AASd-119:
 
@@ -691,6 +687,10 @@ class Qualifiable(Class):
         equal to :py:attr:`QualifierKind.TEMPLATE_QUALIFIER` and the qualified element
         inherits from :py:class:`HasKind` then the qualified element shall be of
         kind Template (:py:attr:`HasKind.kind` = :py:attr:`ModellingKind.TEMPLATE`).
+
+        .. note::
+
+            This constraint is checked at :py:class:`Submodel`.
     """
 
     #: Additional qualification of a qualifiable element.
@@ -1063,28 +1063,28 @@ class AssetInformation(Class):
     does not already exist, the corresponding attribute :py:attr:`global_asset_id` is
     optional.
 
-    .. note::
-
-        :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across global
-        and specific asset IDs.
-
-    .. note::
-
-        In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
-        case-insensitive equality against ``globalAssetId``. This is
-        culturally-dependent, and depends on the system settings.
-        For example, the case-folding for the letters "i" and "I" is
-        different in Turkish from English.
-
-        We implement the constraint as case-sensitive instead to allow
-        for interoperability across different culture settings.
-
     :constraint AASd-116:
         .. _constraint_AASd-116:
 
         ``globalAssetId`` is a reserved key. If used as value for
         :py:attr:`SpecificAssetID.name` then :py:attr:`SpecificAssetID.value` shall be
         identical to :py:attr:`global_asset_id`.
+
+        .. note::
+
+            :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across
+            global and specific asset IDs.
+
+        .. note::
+
+            In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
+            case-insensitive equality against ``globalAssetId``. This is
+            culturally-dependent, and depends on the system settings.
+            For example, the case-folding for the letters "i" and "I" is
+            different in Turkish from English.
+
+            We implement the constraint as case-sensitive instead to allow
+            for interoperability across different culture settings.
 
     :constraint AASd-131:
         .. _constraint_AASd-131:
@@ -4585,25 +4585,60 @@ class ConceptDescription(Identifiable, HasDataSpecification):
     The description of the concept should follow a standardized schema (realized as
     data specification template).
 
-    .. note::
+    :constraint AASc-3a-004:
+        .. _constraint_AASc-3a-004:
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``PROPERTY`` or
+        ``VALUE`` using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        one of: ``DATE``, ``STRING``, ``STRING_TRANSLATABLE``, ``INTEGER_MEASURE``,
+        ``INTEGER_COUNT``, ``INTEGER_CURRENCY``, ``REAL_MEASURE``, ``REAL_COUNT``,
+        ``REAL_CURRENCY``, ``BOOLEAN``, ``RATIONAL``, ``RATIONAL_MEASURE``,
+        ``TIME``, ``TIMESTAMP``.
 
-    .. note::
+        .. note::
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
-    .. note::
+    :constraint AASc-3a-005:
+        .. _constraint_AASc-3a-005:
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``REFERENCE``
+        using data specification template IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be
+        one of: ``STRING``, ``IRI``, ``IRDI``.
 
-    .. note::
+        .. note::
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-006:
+        .. _constraint_AASc-3a-006:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``DOCUMENT``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be one of ``FILE``,
+        ``BLOB``, ``HTML``
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-007:
+        .. _constraint_AASc-3a-007:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``QUALIFIER_TYPE``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        defined.
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
     :constraint AASc-3a-008:
         .. _constraint_AASc-3a-008:
@@ -6189,20 +6224,6 @@ class DataSpecificationIEC61360(DataSpecificationContent):
 
     .. note::
 
-        It is also possible that both :py:attr:`value` and :py:attr:`value_list` are empty.
-        This is the case for concept descriptions that define the semantics of a
-        property but do not have an enumeration (:py:attr:`value_list`) as data type.
-
-    .. note::
-
-        Although it is possible to define a :py:class:`ConceptDescription` for a
-        :attr:´value_list`,
-        it is not possible to reuse this :py:attr:`value_list`.
-        It is only possible to directly add a :py:attr:`value_list` as data type
-        to a specific semantic definition of a property.
-
-    .. note::
-
         IEC61360 requires also a globally unique identifier for a concept
         description. This ID is not part of the data specification template.
         Instead the :py:attr:`ConceptDescription.id` as inherited via
@@ -6217,6 +6238,27 @@ class DataSpecificationIEC61360(DataSpecificationContent):
         :py:attr:`ConceptDescription.display_name` and
         :py:attr:`preferred_name`. Same holds for
         :py:attr:`ConceptDescription.description` and :py:attr:`definition`.
+
+    :constraint AASc-3a-010:
+        .. _constraint_AASc-3a-010:
+
+        If :py:attr:`value` is not empty then :py:attr:`value_list` shall be empty
+        and vice versa.
+
+        .. note::
+
+            It is also possible that both :py:attr:`value` and :py:attr:`value_list` are
+            empty. This is the case for concept descriptions that define the semantics
+            of a property but do not have an enumeration (:py:attr:`value_list`) as
+            data type.
+
+        .. note::
+
+            Although it is possible to define a :py:class:`ConceptDescription` for a
+            :attr:´value_list`,
+            it is not possible to reuse this :py:attr:`value_list`.
+            It is only possible to directly add a :py:attr:`value_list` as data type
+            to a specific semantic definition of a property.
 
     :constraint AASc-3a-009:
         .. _constraint_AASc-3a-009:

--- a/_dev_scripts/aas_core3/verification.py
+++ b/_dev_scripts/aas_core3/verification.py
@@ -2439,7 +2439,8 @@ class _Transformer(
                         specific_asset_id.name != 'globalAssetId'
                         or (
                             (
-                                specific_asset_id.name == 'globalAssetId'
+                                (that.global_asset_id is not None)
+                                and specific_asset_id.name == 'globalAssetId'
                                 and specific_asset_id.value == that.global_asset_id
                             )
                         )
@@ -2784,7 +2785,7 @@ class _Transformer(
         if not (
             not (that.submodel_elements is not None)
             or (
-                not (that.kind != aas_types.ModellingKind.TEMPLATE)
+                not (that.kind_or_default() != aas_types.ModellingKind.TEMPLATE)
                 or (
                     all(
                         not (submodel_element.qualifiers is not None)
@@ -8085,7 +8086,7 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.data_type is None)
+                    (that.data_type is not None)
                     and (that.data_type in aas_constants.IEC_61360_DATA_TYPES_WITH_UNIT)
                 )
             )

--- a/_dev_scripts/continuous_integration_of_dev_scripts/precommit.py
+++ b/_dev_scripts/continuous_integration_of_dev_scripts/precommit.py
@@ -107,6 +107,7 @@ def main() -> int:
             "test_codegen",
             "continuous_integration_of_dev_scripts",
             "setup.py",
+            "update_to_aas_core_meta_codegen_and_testgen.py",
         ]
         if overwrite:
             exit_code = call_and_report(
@@ -133,6 +134,7 @@ def main() -> int:
             "codegen",
             "test_codegen",
             "continuous_integration_of_dev_scripts",
+            "update_to_aas_core_meta_codegen_and_testgen.py",
         ]
         config_file = pathlib.Path("continuous_integration_of_dev_scripts") / "mypy.ini"
 
@@ -152,6 +154,7 @@ def main() -> int:
             "codegen",
             "test_codegen",
             "continuous_integration_of_dev_scripts",
+            "update_to_aas_core_meta_codegen_and_testgen.py",
         ]
         rcfile = pathlib.Path("continuous_integration_of_dev_scripts") / "pylint.rc"
 

--- a/_dev_scripts/setup.py
+++ b/_dev_scripts/setup.py
@@ -29,8 +29,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@2a81612#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@d989ed6#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@607f65c#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={

--- a/types/types.go
+++ b/types/types.go
@@ -1050,13 +1050,13 @@ func NewAdministrativeInformation() *AdministrativeInformation {
 // The value of a qualifiable element may be further qualified by one or more
 // qualifiers.
 //
-// NOTE: This constraint is checked at [ISubmodel].
-//
 // Constraint AASd-119:
 // If any [IQualifier.Kind] value of [IQualifiable.Qualifiers] is
 // equal to [QualifierKindTemplateQualifier] and the qualified element
 // inherits from [IHasKind] then the qualified element shall be of
 // kind Template ([IHasKind.Kind] = [ModellingKindTemplate]).
+//
+// NOTE: This constraint is checked at [ISubmodel].
 type IQualifiable interface {
 	IClass
 
@@ -1858,8 +1858,13 @@ func NewAssetAdministrationShell(
 // does not already exist, the corresponding attribute [IAssetInformation.GlobalAssetID] is
 // optional.
 //
-// NOTE: Constraint AASd-116 is important to enable a generic search across global
-// and specific asset IDs.
+// Constraint AASd-116:
+// `globalAssetId` is a reserved key. If used as value for
+// [ISpecificAssetID.Name] then [ISpecificAssetID.Value] shall be
+// identical to [IAssetInformation.GlobalAssetID].
+//
+// NOTE: Constraint AASd-116 is important to enable a generic search across
+// global and specific asset IDs.
 //
 // NOTE: In the book, Constraint AASd-116 imposes a
 // case-insensitive equality against `globalAssetId`. This is
@@ -1869,11 +1874,6 @@ func NewAssetAdministrationShell(
 //
 // We implement the constraint as case-sensitive instead to allow
 // for interoperability across different culture settings.
-//
-// Constraint AASd-116:
-// `globalAssetId` is a reserved key. If used as value for
-// [ISpecificAssetID.Name] then [ISpecificAssetID.Value] shall be
-// identical to [IAssetInformation.GlobalAssetID].
 //
 // Constraint AASd-131:
 // For [IAssetInformation] either the [IAssetInformation.GlobalAssetID] shall be
@@ -9803,14 +9803,41 @@ func NewCapability() *Capability {
 // The description of the concept should follow a standardized schema (realized as
 // data specification template).
 //
-// NOTE: Note: categories are deprecated since V3.0 of Part 1a of the document series
-// "Details of the Asset Administration Shell".
+// Constraint AASc-3a-004:
+// For a [IConceptDescription] with [IConceptDescription.Category] `PROPERTY` or
+// `VALUE` using data specification IEC61360,
+// the [IDataSpecificationIEC61360.DataType] is mandatory and shall be
+// one of: `DATE`, `STRING`, `STRING_TRANSLATABLE`, `INTEGER_MEASURE`,
+// `INTEGER_COUNT`, `INTEGER_CURRENCY`, `REAL_MEASURE`, `REAL_COUNT`,
+// `REAL_CURRENCY`, `BOOLEAN`, `RATIONAL`, `RATIONAL_MEASURE`,
+// `TIME`, `TIMESTAMP`.
 //
 // NOTE: Note: categories are deprecated since V3.0 of Part 1a of the document series
 // "Details of the Asset Administration Shell".
+//
+// Constraint AASc-3a-005:
+// For a [IConceptDescription] with [IConceptDescription.Category] `REFERENCE`
+// using data specification template IEC61360,
+// the [IDataSpecificationIEC61360.DataType] shall be
+// one of: `STRING`, `IRI`, `IRDI`.
+//
+// NOTE: Note: categories are deprecated since V3.0 of Part 1a of the document series
+// "Details of the Asset Administration Shell".
+//
+// Constraint AASc-3a-006:
+// For a [IConceptDescription] with [IConceptDescription.Category] `DOCUMENT`
+// using data specification IEC61360,
+// the [IDataSpecificationIEC61360.DataType] shall be one of `FILE`,
+// `BLOB`, `HTML`
 //
 // NOTE: Categories are deprecated since V3.0 of Part 1a of the document series
 // "Details of the Asset Administration Shell".
+//
+// Constraint AASc-3a-007:
+// For a [IConceptDescription] with [IConceptDescription.Category] `QUALIFIER_TYPE`
+// using data specification IEC61360,
+// the [IDataSpecificationIEC61360.DataType] is mandatory and shall be
+// defined.
 //
 // NOTE: Categories are deprecated since V3.0 of Part 1a of the document series
 // "Details of the Asset Administration Shell".
@@ -12052,16 +12079,6 @@ func NewLangStringDefinitionTypeIEC61360(
 // Content of data specification template for concept descriptions for properties,
 // values and value lists conformant to IEC 61360.
 //
-// NOTE: It is also possible that both [IDataSpecificationIEC61360.Value] and [IDataSpecificationIEC61360.ValueList] are empty.
-// This is the case for concept descriptions that define the semantics of a
-// property but do not have an enumeration ([IDataSpecificationIEC61360.ValueList]) as data type.
-//
-// NOTE: Although it is possible to define a [IConceptDescription] for a
-// :attr:´value_list`,
-// it is not possible to reuse this [IDataSpecificationIEC61360.ValueList].
-// It is only possible to directly add a [IDataSpecificationIEC61360.ValueList] as data type
-// to a specific semantic definition of a property.
-//
 // NOTE: IEC61360 requires also a globally unique identifier for a concept
 // description. This ID is not part of the data specification template.
 // Instead the [IConceptDescription.ID] as inherited via
@@ -12074,6 +12091,21 @@ func NewLangStringDefinitionTypeIEC61360(
 // [IConceptDescription.DisplayName] and
 // [IDataSpecificationIEC61360.PreferredName]. Same holds for
 // [IConceptDescription.Description] and [IDataSpecificationIEC61360.Definition].
+//
+// Constraint AASc-3a-010:
+// If [IDataSpecificationIEC61360.Value] is not empty then [IDataSpecificationIEC61360.ValueList] shall be empty
+// and vice versa.
+//
+// NOTE: It is also possible that both [IDataSpecificationIEC61360.Value] and [IDataSpecificationIEC61360.ValueList] are
+// empty. This is the case for concept descriptions that define the semantics
+// of a property but do not have an enumeration ([IDataSpecificationIEC61360.ValueList]) as
+// data type.
+//
+// NOTE: Although it is possible to define a [IConceptDescription] for a
+// :attr:´value_list`,
+// it is not possible to reuse this [IDataSpecificationIEC61360.ValueList].
+// It is only possible to directly add a [IDataSpecificationIEC61360.ValueList] as data type
+// to a specific semantic definition of a property.
 //
 // Constraint AASc-3a-009:
 // If [IDataSpecificationIEC61360.DataType] one of:

--- a/xmlization/test/generated_of_concrete_classes_test.go
+++ b/xmlization/test/generated_of_concrete_classes_test.go
@@ -6,16 +6,16 @@ package xmlization_test
 
 import (
 	"bytes"
-	"path/filepath"
-	"fmt"
-	"os"
-	"sort"
-	"strings"
-	"testing"
 	"encoding/xml"
+	"fmt"
 	aastesting "github.com/aas-core-works/aas-core3.0-golang/aastesting"
 	aastypes "github.com/aas-core-works/aas-core3.0-golang/types"
 	aasxmlization "github.com/aas-core-works/aas-core3.0-golang/xmlization"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
 )
 
 func TestExtensionRoundTripOK(t *testing.T) {
@@ -54,7 +54,7 @@ func TestExtensionRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -169,7 +169,7 @@ func TestAdministrativeInformationRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -284,7 +284,7 @@ func TestQualifierRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -399,7 +399,7 @@ func TestAssetAdministrationShellRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -514,7 +514,7 @@ func TestAssetInformationRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -629,7 +629,7 @@ func TestResourceRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -744,7 +744,7 @@ func TestSpecificAssetIDRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -859,7 +859,7 @@ func TestSubmodelRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -974,7 +974,7 @@ func TestRelationshipElementRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1089,7 +1089,7 @@ func TestSubmodelElementListRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1204,7 +1204,7 @@ func TestSubmodelElementCollectionRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1319,7 +1319,7 @@ func TestPropertyRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1434,7 +1434,7 @@ func TestMultiLanguagePropertyRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1549,7 +1549,7 @@ func TestRangeRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1664,7 +1664,7 @@ func TestReferenceElementRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1779,7 +1779,7 @@ func TestBlobRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -1894,7 +1894,7 @@ func TestFileRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2009,7 +2009,7 @@ func TestAnnotatedRelationshipElementRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2124,7 +2124,7 @@ func TestEntityRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2239,7 +2239,7 @@ func TestEventPayloadRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2354,7 +2354,7 @@ func TestBasicEventElementRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2469,7 +2469,7 @@ func TestOperationRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2584,7 +2584,7 @@ func TestOperationVariableRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2699,7 +2699,7 @@ func TestCapabilityRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2814,7 +2814,7 @@ func TestConceptDescriptionRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -2929,7 +2929,7 @@ func TestReferenceRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3044,7 +3044,7 @@ func TestKeyRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3159,7 +3159,7 @@ func TestLangStringNameTypeRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3274,7 +3274,7 @@ func TestLangStringTextTypeRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3389,7 +3389,7 @@ func TestEnvironmentRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3504,7 +3504,7 @@ func TestEmbeddedDataSpecificationRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3619,7 +3619,7 @@ func TestLevelTypeRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3734,7 +3734,7 @@ func TestValueReferencePairRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3849,7 +3849,7 @@ func TestValueListRoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -3964,7 +3964,7 @@ func TestLangStringPreferredNameTypeIEC61360RoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -4079,7 +4079,7 @@ func TestLangStringShortNameTypeIEC61360RoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -4194,7 +4194,7 @@ func TestLangStringDefinitionTypeIEC61360RoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)
@@ -4309,7 +4309,7 @@ func TestDataSpecificationIEC61360RoundTripOK(t *testing.T) {
 				deserialized, deserialized,
 			)
 			return
-		} 
+		}
 
 		buf := &bytes.Buffer{}
 		encoder := xml.NewEncoder(buf)


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 44756fb],
* [aas-core-codegen 607f65c] and
* [aas-core3.0-testgen bf3720d7].

This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:

* Pull request in aas-core-meta [#275] which affects the documentation of many constraints.

Additionally, we fix the update script as this was the first time that we are using it and there were a couple of infantile deseases.

[aas-core-meta 44756fb]: https://github.com/aas-core-works/aas-core-meta/commit/44756fb
[aas-core-codegen 607f65c]: https://github.com/aas-core-works/aas-core-codegen/commit/607f65c
[aas-core3.0-testgen bf3720d7]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/bf3720d7

[#275]: https://github.com/aas-core-works/aas-core-meta/pull/275