### PR TITLE
Update to aas-core-meta, codegen, testgen 4d7e59e, 7e264a0, 9b43de2e

### DIFF
--- a/_dev_scripts/aas_core3/__init__.py
+++ b/_dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 607f65c
+The revision of aas-core-codegen was: 7e264a0
 """

--- a/_dev_scripts/aas_core3/verification.py
+++ b/_dev_scripts/aas_core3/verification.py
@@ -130,6 +130,9 @@ class Error:
         self.cause = cause
         self.path = Path()
 
+    def __repr__(self) -> str:
+        return f"Error(path={self.path}, cause={self.cause})"
+
 
 # noinspection SpellCheckingInspection
 def _construct_matches_id_short() -> Pattern[str]:
@@ -2461,15 +2464,12 @@ class _Transformer(
                 (
                 (
                     (that.global_asset_id is not None)
-                    and (that.specific_asset_ids is None)
+                    or (that.specific_asset_ids is not None)
                 )
             )
-                or (
-                    (
-                        (that.global_asset_id is None)
-                        and (that.specific_asset_ids is not None)
-                        and len(that.specific_asset_ids) >= 1
-                    )
+                and (
+                    not (that.specific_asset_ids is not None)
+                    or (len(that.specific_asset_ids) >= 1)
                 )
             )
         ):
@@ -8062,21 +8062,10 @@ class _Transformer(
             that: aas_types.DataSpecificationIEC61360
     ) -> Iterator[Error]:
         if not (
-            (
-                (
-                (
-                    (that.value is not None)
-                    and (that.value_list is None)
-                )
-            )
-                or (
-                    (
-                        (that.value is None)
-                        and (that.value_list is not None)
-                        and len(that.value_list.value_reference_pairs) >= 1
-                    )
-                )
-            )
+            not ((
+                (that.value is not None)
+                and (that.value_list is not None)
+            ))
         ):
             yield Error(
                 'Constraint AASc-3a-010: If value is not empty then value ' +

--- a/_dev_scripts/setup.py
+++ b/_dev_scripts/setup.py
@@ -29,8 +29,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@607f65c#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@7e264a0#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={

--- a/testdata/VerificationError/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
+++ b/testdata/VerificationError/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
@@ -1,2 +1,1 @@
-AssetAdministrationShells[0].EmbeddedDataSpecifications[0].DataSpecificationContent: Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.;
 AssetAdministrationShells[0].EmbeddedDataSpecifications[0].DataSpecificationContent.ValueList: Value reference pair types must contain at least one item.

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -3698,11 +3698,10 @@ func VerifyAssetInformation(
 		}
 	}
 
-	if !(((that.GlobalAssetID() != nil) &&
-		(that.SpecificAssetIDs() == nil)) ||
-		((that.GlobalAssetID() == nil) &&
-			(that.SpecificAssetIDs() != nil) &&
-			len(that.SpecificAssetIDs()) >= 1)) {
+	if !(((that.GlobalAssetID() != nil) ||
+		(that.SpecificAssetIDs() != nil)) &&
+		(!(that.SpecificAssetIDs() != nil) ||
+			(len(that.SpecificAssetIDs()) >= 1))) {
 		abort = onError(
 			newVerificationError(
 				"Constraint AASd-131: Either the global asset ID shall be " +
@@ -12424,11 +12423,8 @@ func VerifyDataSpecificationIEC61360(
 ) (abort bool) {
 	abort = false
 
-	if !(((that.Value() != nil) &&
-		(that.ValueList() == nil)) ||
-		((that.Value() == nil) &&
-			(that.ValueList() != nil) &&
-			len(that.ValueList().ValueReferencePairs()) >= 1)) {
+	if !(!((that.Value() != nil) &&
+		(that.ValueList() != nil))) {
 		abort = onError(
 			newVerificationError(
 				"Constraint AASc-3a-010: If value is not empty then value " +


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 4d7e59e],
* [aas-core-codegen 7e264a0] and
* [aas-core3.0-testgen 9b43de2e].

Notably, this includes two important fixes from aas-core-meta:

* [V3 Fix AASc-3a-010-for-NAND (#281)], and
* [V3 Fix inclusive OR in AASd-131 (#280)].

[aas-core-meta 4d7e59e]: https://github.com/aas-core-works/aas-core-meta/commit/4d7e59e
[aas-core-codegen 7e264a0]: https://github.com/aas-core-works/aas-core-codegen/commit/7e264a0
[aas-core3.0-testgen 9b43de2e]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9b43de2e
[V3 Fix AASc-3a-010-for-NAND (#281)]: https://github.com/aas-core-works/aas-core-meta/pull/281
[V3 Fix inclusive OR in AASd-131 (#280)]: https://github.com/aas-core-works/aas-core-meta/pull/280