### PR TITLE
Release 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,11 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Change Log
 
+### v1.0.3 (2024-04-16)
+
+The `dataSpecification` field in `EmbeddedDataSpecification` is made
+optional, according to the book.
+
 ### v1.0.2 (2024-03-23)
 
 * Update to aas-core-meta, codegen, testgen cb28d18, c414f32, 6ff39c260 (#17)


### PR DESCRIPTION
The `dataSpecification` field in `EmbeddedDataSpecification` is made optional, according to the book.