### PR TITLE
Document the versatility of XML de-serialization

### DIFF
--- a/getting_started/xmlization_from_file_test.go
+++ b/getting_started/xmlization_from_file_test.go
@@ -1,0 +1,97 @@
+package getting_started_test
+
+import (
+	"encoding/xml"
+	"fmt"
+	aasstringification "github.com/aas-core-works/aas-core3.0-golang/stringification"
+	aastypes "github.com/aas-core-works/aas-core3.0-golang/types"
+	aasxmlization "github.com/aas-core-works/aas-core3.0-golang/xmlization"
+	"log"
+	"strings"
+)
+
+// TokenReaderSkipDeclaration reads tokens from a reader and
+// skips the XML declarations.
+type TokenReaderSkipDeclaration struct {
+	r xml.TokenReader
+}
+
+func NewTokenReaderSkipDeclaration(r xml.TokenReader) *TokenReaderSkipDeclaration {
+	return &TokenReaderSkipDeclaration{r: r}
+}
+
+func (trsd *TokenReaderSkipDeclaration) Token() (xml.Token, error) {
+	var token xml.Token
+	var err error
+
+	for {
+		token, err = trsd.r.Token()
+		if err != nil {
+			return token, err
+		}
+
+		if _, isProcInst := token.(xml.ProcInst); !isProcInst {
+			return token, err
+		}
+	}
+}
+
+func Example_xmlizationFromTextWithBOMAndXMLDeclaration() {
+	// "\uFEFF" is a Byte Order Mark.
+	text := "\uFEFF" + `<?xml version="1.0" encoding="UTF-8" ?>
+<environment xmlns="https://admin-shell.io/aas/3/0">
+  <submodels>
+    <submodel>
+      <id>some-unique-global-identifier</id>
+      <submodelElements>
+        <property>
+          <idShort>someProperty</idShort>
+          <valueType>xs:string</valueType>
+          <value>some-value</value>
+        </property>
+      </submodelElements>
+    </submodel>
+  </submodels>
+</environment>`
+
+	reader := strings.NewReader(text)
+
+	// Try to read the Byte Order Mark
+	var err error
+	rune, _, err := reader.ReadRune()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if rune != '\uFEFF' {
+		reader.UnreadRune()
+	}
+
+	// Use a decoder which skips the XML declarations
+	decoder := xml.NewTokenDecoder(
+		NewTokenReaderSkipDeclaration(
+			xml.NewDecoder(reader),
+		),
+	)
+
+	var instance aastypes.IClass
+	instance, err = aasxmlization.Unmarshal(
+		decoder,
+	)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	instance.Descend(
+		func(that aastypes.IClass) (abort bool) {
+			fmt.Printf(
+				"%s\n",
+				aasstringification.MustModelTypeToString(that.ModelType()),
+			)
+			return
+		},
+	)
+
+	// Output:
+	// Submodel
+	// Property
+}

--- a/getting_started/xmlization_skip_attributes_test.go
+++ b/getting_started/xmlization_skip_attributes_test.go
@@ -1,0 +1,95 @@
+package getting_started_test
+
+import (
+	"encoding/xml"
+	"fmt"
+	aasstringification "github.com/aas-core-works/aas-core3.0-golang/stringification"
+	aastypes "github.com/aas-core-works/aas-core3.0-golang/types"
+	aasxmlization "github.com/aas-core-works/aas-core3.0-golang/xmlization"
+	"strings"
+)
+
+// TokenReaderNoAttributes reads tokens from a reader and
+// removes any attributes in the start elements.
+type TokenReaderNoAttributes struct {
+	r xml.TokenReader
+}
+
+func NewTokenReaderNoAttributes(r xml.TokenReader) *TokenReaderNoAttributes {
+	return &TokenReaderNoAttributes{r: r}
+}
+
+func (trna *TokenReaderNoAttributes) Token() (xml.Token, error) {
+	var token xml.Token
+	var err error
+
+	for {
+		token, err = trna.r.Token()
+		if err != nil {
+			return token, err
+		}
+
+		var startElement xml.StartElement
+		startElement, isStartElement := token.(xml.StartElement)
+
+		if !isStartElement {
+			return token, err
+		}
+
+		startElement.Attr = []xml.Attr{}
+		return startElement, err
+	}
+}
+
+func Example_xmlizationSkipAttributes() {
+	text := `<environment
+	xmlns="https://admin-shell.io/aas/3/0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://admin-shell.io/aas/3/0 AAS.xsd"
+>
+  <submodels>
+    <submodel>
+      <id>some-unique-global-identifier</id>
+      <submodelElements>
+        <property>
+          <idShort>someProperty</idShort>
+          <valueType>xs:string</valueType>
+          <value>some-value</value>
+        </property>
+      </submodelElements>
+    </submodel>
+  </submodels>
+</environment>`
+
+	reader := strings.NewReader(text)
+
+	// Use a decoder which skips the XML declarations
+	decoder := xml.NewTokenDecoder(
+		NewTokenReaderNoAttributes(
+			xml.NewDecoder(reader),
+		),
+	)
+
+	var instance aastypes.IClass
+	var err error
+	instance, err = aasxmlization.Unmarshal(
+		decoder,
+	)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	instance.Descend(
+		func(that aastypes.IClass) (abort bool) {
+			fmt.Printf(
+				"%s\n",
+				aasstringification.MustModelTypeToString(that.ModelType()),
+			)
+			return
+		},
+	)
+
+	// Output:
+	// Submodel
+	// Property
+}


### PR DESCRIPTION
We document in the Readme a couple of recipes how to make the XML de-serialization versatile with the respect to text prefix and XML attributes.

Fixes #22, fixes #23.