### PR TITLE
Ignore attributes prefixed with `xmlns`

### DIFF
--- a/getting_started/xmlization_namespace_alias_test.go
+++ b/getting_started/xmlization_namespace_alias_test.go
@@ -1,0 +1,56 @@
+package getting_started_test
+
+import (
+	"encoding/xml"
+	"fmt"
+	aasstringification "github.com/aas-core-works/aas-core3.0-golang/stringification"
+	aastypes "github.com/aas-core-works/aas-core3.0-golang/types"
+	aasxmlization "github.com/aas-core-works/aas-core3.0-golang/xmlization"
+	"strings"
+)
+
+func Example_xmlizationNamespaceAlias() {
+	text := `<aas:environment
+	xmlns:aas="https://admin-shell.io/aas/3/0"
+>
+  <aas:submodels>
+    <aas:submodel>
+      <aas:id>some-unique-global-identifier</aas:id>
+      <aas:submodelElements>
+        <aas:property>
+          <aas:idShort>someProperty</aas:idShort>
+          <aas:valueType>xs:string</aas:valueType>
+          <aas:value>some-value</aas:value>
+        </aas:property>
+      </aas:submodelElements>
+    </aas:submodel>
+  </aas:submodels>
+</aas:environment>`
+
+	reader := strings.NewReader(text)
+
+	decoder := xml.NewDecoder(reader)
+
+	var instance aastypes.IClass
+	var err error
+	instance, err = aasxmlization.Unmarshal(
+		decoder,
+	)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	instance.Descend(
+		func(that aastypes.IClass) (abort bool) {
+			fmt.Printf(
+				"%s\n",
+				aasstringification.MustModelTypeToString(that.ModelType()),
+			)
+			return
+		},
+	)
+
+	// Output:
+	// Submodel
+	// Property
+}

--- a/xmlization/xmlization.go
+++ b/xmlization/xmlization.go
@@ -344,19 +344,23 @@ const Namespace = "https://admin-shell.io/aas/3/0"
 func checkStartElement(
 	current xml.StartElement,
 ) (err error) {
-	var unexpectedAttr []xml.Attr
+	const xmlnsLen = len("xmlns")
+
+	unexpectedAttr := 0
 	for _, attr := range current.Attr {
-		if attr.Name.Space == "" && attr.Name.Local == "xmlns" {
+		if (attr.Name.Space == "" && attr.Name.Local == "xmlns") ||
+			attr.Name.Space == "xmlns" {
 			continue
 		}
-		unexpectedAttr = append(unexpectedAttr, attr)
+
+		unexpectedAttr++
 	}
-	if len(unexpectedAttr) != 0 {
+	if unexpectedAttr != 0 {
 		err = newDeserializationError(
 			fmt.Sprintf(
 				"Expected no attributes except 'xmlns' in the start element, "+
 					"but got %d in the start element %s",
-				len(unexpectedAttr), current.Name.Local,
+				unexpectedAttr, current.Name.Local,
 			),
 		)
 		return


### PR DESCRIPTION
We ignore both the `xmlns` attribute as well as attributes prefixed with `xmlns:` since they are necessary for correct namespacing even though the AAS specs does not allow any attributes.

Fixes #25.