### PR TITLE
Fix the error message in jsonization for strings

### DIFF
--- a/jsonization/jsonization.go
+++ b/jsonization/jsonization.go
@@ -178,7 +178,7 @@ func stringFromJsonable(
 		return
 	} else {
 		err = newDeserializationError(
-			fmt.Sprintf("Expected a boolean, but got %T", jsonable),
+			fmt.Sprintf("Expected a string, but got %T", jsonable),
 		)
 		return
 	}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/revision.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/revision.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration.revision: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].administration.revision: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/templateId.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/templateId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration.templateId: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].administration.templateId: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/version.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/version.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration.version: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].administration.version: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/category.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].category: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/id.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/id.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].id: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].id: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/idShort.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].idShort: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetInformation/assetType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetInformation/assetType.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.assetType: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.assetType: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetInformation/globalAssetId.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetInformation/globalAssetId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.globalAssetId: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.globalAssetId: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/lastUpdate.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/lastUpdate.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].lastUpdate: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].lastUpdate: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/maxInterval.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/maxInterval.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].maxInterval: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].maxInterval: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/messageTopic.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/messageTopic.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].messageTopic: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].messageTopic: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/minInterval.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/minInterval.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].minInterval: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].minInterval: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/contentType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/contentType.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].contentType: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].contentType: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/category.json.error
@@ -1,1 +1,1 @@
-conceptDescriptions[0].category: Expected a boolean, but got []interface {}
+conceptDescriptions[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/id.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/id.json.error
@@ -1,1 +1,1 @@
-conceptDescriptions[0].id: Expected a boolean, but got []interface {}
+conceptDescriptions[0].id: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/idShort.json.error
@@ -1,1 +1,1 @@
-conceptDescriptions[0].idShort: Expected a boolean, but got []interface {}
+conceptDescriptions[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/sourceOfDefinition.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/sourceOfDefinition.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.sourceOfDefinition: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.sourceOfDefinition: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/symbol.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/symbol.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.symbol: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.symbol: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/unit.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/unit.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unit: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unit: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/value.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.value: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/valueFormat.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/valueFormat.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueFormat: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueFormat: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/name.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/name.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].name: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].extensions[0].name: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/value.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].value: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].extensions[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/contentType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/contentType.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].contentType: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].contentType: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/value.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Key/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Key/value.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].derivedFrom.keys[0].value: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].derivedFrom.keys[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringDefinitionTypeIec61360/language.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringDefinitionTypeIec61360/language.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition[0].language: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition[0].language: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringDefinitionTypeIec61360/text.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringDefinitionTypeIec61360/text.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition[0].text: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition[0].text: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringNameType/language.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringNameType/language.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].displayName[0].language: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].displayName[0].language: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringNameType/text.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringNameType/text.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].displayName[0].text: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].displayName[0].text: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringPreferredNameTypeIec61360/language.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringPreferredNameTypeIec61360/language.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName[0].language: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName[0].language: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringPreferredNameTypeIec61360/text.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringPreferredNameTypeIec61360/text.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName[0].text: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName[0].text: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringShortNameTypeIec61360/language.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringShortNameTypeIec61360/language.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName[0].language: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName[0].language: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringShortNameTypeIec61360/text.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringShortNameTypeIec61360/text.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName[0].text: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName[0].text: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringTextType/language.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringTextType/language.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].description[0].language: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].description[0].language: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringTextType/text.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/LangStringTextType/text.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].description[0].text: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].description[0].text: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/value.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/type.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/type.json.error
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].type: Expected a boolean, but got []interface {}
+submodels[0].qualifiers[0].type: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/value.json.error
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].value: Expected a boolean, but got []interface {}
+submodels[0].qualifiers[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/max.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/max.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].max: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].max: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Resource/contentType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Resource/contentType.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.defaultThumbnail.contentType: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.defaultThumbnail.contentType: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Resource/path.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Resource/path.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.defaultThumbnail.path: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.defaultThumbnail.path: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/name.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/name.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.specificAssetIds[0].name: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.specificAssetIds[0].name: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/value.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.specificAssetIds[0].value: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].assetInformation.specificAssetIds[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].category: Expected a boolean, but got []interface {}
+submodels[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/id.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/id.json.error
@@ -1,1 +1,1 @@
-submodels[0].id: Expected a boolean, but got []interface {}
+submodels[0].id: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/category.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/category.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].category: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].category: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/idShort.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/idShort.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].idShort: Expected a boolean, but got []interface {}
+submodels[0].submodelElements[0].idShort: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ValueReferencePair/value.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ValueReferencePair/value.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].value: Expected a boolean, but got []interface {}
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].value: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/SelfContained/Unexpected/Unserializable/TypeViolation/EventPayload/timeStamp.json.error
+++ b/testdata/DeserializationError/Json/SelfContained/Unexpected/Unserializable/TypeViolation/EventPayload/timeStamp.json.error
@@ -1,1 +1,1 @@
-timeStamp: Expected a boolean, but got []interface {}
+timeStamp: Expected a string, but got []interface {}

--- a/testdata/DeserializationError/Json/SelfContained/Unexpected/Unserializable/TypeViolation/EventPayload/topic.json.error
+++ b/testdata/DeserializationError/Json/SelfContained/Unexpected/Unserializable/TypeViolation/EventPayload/topic.json.error
@@ -1,1 +1,1 @@
-topic: Expected a boolean, but got []interface {}
+topic: Expected a string, but got []interface {}


### PR DESCRIPTION
We erroneously copy-pasted the error message from the function for de-serialization of booleans to the function for de-serialization of strings, misleading the user.

This patch fixes the issue.

The problem unfortunately went unnoticed during the review.