### PR TITLE
Check explicitly for invalid model types

### DIFF
--- a/jsonization/jsonization.go
+++ b/jsonization/jsonization.go
@@ -1275,6 +1275,8 @@ func assetAdministrationShellFromMapWithoutDispatch(
 	foundID := false
 	foundAssetInformation := false
 
+	var foundModelType bool
+
 	for k, v := range m {
 		switch k {
 		case "extensions":
@@ -1634,8 +1636,40 @@ func assetAdministrationShellFromMapWithoutDispatch(
 			theSubmodels = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "AssetAdministrationShell" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'AssetAdministrationShell', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -1658,6 +1692,13 @@ func assetAdministrationShellFromMapWithoutDispatch(
 	if !foundAssetInformation {
 		err = newDeserializationError(
 			"The required property 'assetInformation' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -2308,6 +2349,8 @@ func submodelFromMapWithoutDispatch(
 
 	foundID := false
 
+	var foundModelType bool
+
 	for k, v := range m {
 		switch k {
 		case "extensions":
@@ -2772,8 +2815,40 @@ func submodelFromMapWithoutDispatch(
 			theSubmodelElements = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Submodel" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Submodel', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -2789,6 +2864,13 @@ func submodelFromMapWithoutDispatch(
 	if !foundID {
 		err = newDeserializationError(
 			"The required property 'id' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -2927,6 +3009,8 @@ func relationshipElementFromMapWithoutDispatch(
 
 	foundFirst := false
 	foundSecond := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -3324,8 +3408,40 @@ func relationshipElementFromMapWithoutDispatch(
 			foundSecond = true
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "RelationshipElement" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'RelationshipElement', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -3348,6 +3464,13 @@ func relationshipElementFromMapWithoutDispatch(
 	if !foundSecond {
 		err = newDeserializationError(
 			"The required property 'second' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -3482,6 +3605,8 @@ func submodelElementListFromMapWithoutDispatch(
 	var theValue []aastypes.ISubmodelElement
 
 	foundTypeValueListElement := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -3964,8 +4089,40 @@ func submodelElementListFromMapWithoutDispatch(
 			theValue = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "SubmodelElementList" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'SubmodelElementList', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -3981,6 +4138,13 @@ func submodelElementListFromMapWithoutDispatch(
 	if !foundTypeValueListElement {
 		err = newDeserializationError(
 			"The required property 'typeValueListElement' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -4080,6 +4244,8 @@ func submodelElementCollectionFromMapWithoutDispatch(
 	var theQualifiers []aastypes.IQualifier
 	var theEmbeddedDataSpecifications []aastypes.IEmbeddedDataSpecification
 	var theValue []aastypes.ISubmodelElement
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -4497,8 +4663,40 @@ func submodelElementCollectionFromMapWithoutDispatch(
 			theValue = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "SubmodelElementCollection" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'SubmodelElementCollection', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -4509,6 +4707,13 @@ func submodelElementCollectionFromMapWithoutDispatch(
 			)
 			return
 		}
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
+		)
+		return
 	}
 
 	result = aastypes.NewSubmodelElementCollection()
@@ -4630,6 +4835,8 @@ func propertyFromMapWithoutDispatch(
 	var theValueID aastypes.IReference
 
 	foundValueType := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -5043,8 +5250,40 @@ func propertyFromMapWithoutDispatch(
 			}
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Property" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Property', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -5060,6 +5299,13 @@ func propertyFromMapWithoutDispatch(
 	if !foundValueType {
 		err = newDeserializationError(
 			"The required property 'valueType' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -5154,6 +5400,8 @@ func multiLanguagePropertyFromMapWithoutDispatch(
 	var theEmbeddedDataSpecifications []aastypes.IEmbeddedDataSpecification
 	var theValue []aastypes.ILangStringTextType
 	var theValueID aastypes.IReference
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -5586,8 +5834,40 @@ func multiLanguagePropertyFromMapWithoutDispatch(
 			}
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "MultiLanguageProperty" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'MultiLanguageProperty', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -5598,6 +5878,13 @@ func multiLanguagePropertyFromMapWithoutDispatch(
 			)
 			return
 		}
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
+		)
+		return
 	}
 
 	result = aastypes.NewMultiLanguageProperty()
@@ -5691,6 +5978,8 @@ func rangeFromMapWithoutDispatch(
 	var theMax *string
 
 	foundValueType := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -6106,8 +6395,40 @@ func rangeFromMapWithoutDispatch(
 			theMax = &parsed
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Range" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Range', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -6123,6 +6444,13 @@ func rangeFromMapWithoutDispatch(
 	if !foundValueType {
 		err = newDeserializationError(
 			"The required property 'valueType' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -6216,6 +6544,8 @@ func referenceElementFromMapWithoutDispatch(
 	var theQualifiers []aastypes.IQualifier
 	var theEmbeddedDataSpecifications []aastypes.IEmbeddedDataSpecification
 	var theValue aastypes.IReference
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -6596,8 +6926,40 @@ func referenceElementFromMapWithoutDispatch(
 			}
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "ReferenceElement" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'ReferenceElement', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -6608,6 +6970,13 @@ func referenceElementFromMapWithoutDispatch(
 			)
 			return
 		}
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
+		)
+		return
 	}
 
 	result = aastypes.NewReferenceElement()
@@ -6697,6 +7066,8 @@ func blobFromMapWithoutDispatch(
 	var theContentType string
 
 	foundContentType := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -7093,8 +7464,40 @@ func blobFromMapWithoutDispatch(
 			foundContentType = true
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Blob" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Blob', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -7110,6 +7513,13 @@ func blobFromMapWithoutDispatch(
 	if !foundContentType {
 		err = newDeserializationError(
 			"The required property 'contentType' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -7203,6 +7613,8 @@ func fileFromMapWithoutDispatch(
 	var theContentType string
 
 	foundContentType := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -7601,8 +8013,40 @@ func fileFromMapWithoutDispatch(
 			foundContentType = true
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "File" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'File', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -7618,6 +8062,13 @@ func fileFromMapWithoutDispatch(
 	if !foundContentType {
 		err = newDeserializationError(
 			"The required property 'contentType' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -7713,6 +8164,8 @@ func annotatedRelationshipElementFromMapWithoutDispatch(
 
 	foundFirst := false
 	foundSecond := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -8162,8 +8615,40 @@ func annotatedRelationshipElementFromMapWithoutDispatch(
 			theAnnotations = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "AnnotatedRelationshipElement" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'AnnotatedRelationshipElement', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -8186,6 +8671,13 @@ func annotatedRelationshipElementFromMapWithoutDispatch(
 	if !foundSecond {
 		err = newDeserializationError(
 			"The required property 'second' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -8282,6 +8774,8 @@ func entityFromMapWithoutDispatch(
 	var theSpecificAssetIDs []aastypes.ISpecificAssetID
 
 	foundEntityType := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -8784,8 +9278,40 @@ func entityFromMapWithoutDispatch(
 			theSpecificAssetIDs = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Entity" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Entity', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -8801,6 +9327,13 @@ func entityFromMapWithoutDispatch(
 	if !foundEntityType {
 		err = newDeserializationError(
 			"The required property 'entityType' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -9294,6 +9827,8 @@ func basicEventElementFromMapWithoutDispatch(
 	foundObserved := false
 	foundDirection := false
 	foundState := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -9790,8 +10325,40 @@ func basicEventElementFromMapWithoutDispatch(
 			theMaxInterval = &parsed
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "BasicEventElement" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'BasicEventElement', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -9821,6 +10388,13 @@ func basicEventElementFromMapWithoutDispatch(
 	if !foundState {
 		err = newDeserializationError(
 			"The required property 'state' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -9927,6 +10501,8 @@ func operationFromMapWithoutDispatch(
 	var theInputVariables []aastypes.IOperationVariable
 	var theOutputVariables []aastypes.IOperationVariable
 	var theInoutputVariables []aastypes.IOperationVariable
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -10448,8 +11024,40 @@ func operationFromMapWithoutDispatch(
 			theInoutputVariables = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Operation" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Operation', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -10460,6 +11068,13 @@ func operationFromMapWithoutDispatch(
 			)
 			return
 		}
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
+		)
+		return
 	}
 
 	result = aastypes.NewOperation()
@@ -10637,6 +11252,8 @@ func capabilityFromMapWithoutDispatch(
 	var theSupplementalSemanticIDs []aastypes.IReference
 	var theQualifiers []aastypes.IQualifier
 	var theEmbeddedDataSpecifications []aastypes.IEmbeddedDataSpecification
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -11002,8 +11619,40 @@ func capabilityFromMapWithoutDispatch(
 			theEmbeddedDataSpecifications = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "Capability" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'Capability', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -11014,6 +11663,13 @@ func capabilityFromMapWithoutDispatch(
 			)
 			return
 		}
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
+		)
+		return
 	}
 
 	result = aastypes.NewCapability()
@@ -11098,6 +11754,8 @@ func conceptDescriptionFromMapWithoutDispatch(
 	var theIsCaseOf []aastypes.IReference
 
 	foundID := false
+
+	var foundModelType bool
 
 	for k, v := range m {
 		switch k {
@@ -11427,8 +12085,40 @@ func conceptDescriptionFromMapWithoutDispatch(
 			theIsCaseOf = array
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "ConceptDescription" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'ConceptDescription', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -11444,6 +12134,13 @@ func conceptDescriptionFromMapWithoutDispatch(
 	if !foundID {
 		err = newDeserializationError(
 			"The required property 'id' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13325,6 +14022,8 @@ func dataSpecificationIEC61360FromMapWithoutDispatch(
 
 	foundPreferredName := false
 
+	var foundModelType bool
+
 	for k, v := range m {
 		switch k {
 		case "preferredName":
@@ -13632,8 +14331,40 @@ func dataSpecificationIEC61360FromMapWithoutDispatch(
 			}
 
 		case "modelType":
-			// We ignore the model type as we intentionally dispatched
-			// to this function.
+			var modelType string
+			modelType, err = stringFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "modelType",
+						},
+					)
+				}
+				return
+			}
+
+			if modelType != "DataSpecificationIec61360" {
+				deseriaErr := newDeserializationError(
+					fmt.Sprintf(
+						"Expected the model type 'DataSpecificationIec61360', but got %v",
+						v,
+					),
+				)
+
+				deseriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "modelType",
+					},
+				)
+
+				err = deseriaErr
+				return
+			}
+
+			foundModelType = true
 
 		default:
 			err = newDeserializationError(
@@ -13649,6 +14380,13 @@ func dataSpecificationIEC61360FromMapWithoutDispatch(
 	if !foundPreferredName {
 		err = newDeserializationError(
 			"The required property 'preferredName' is missing",
+		)
+		return
+	}
+
+	if !foundModelType {
+		err = newDeserializationError(
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13706,7 +14444,7 @@ func hasSemanticsFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13787,7 +14525,7 @@ func hasExtensionsFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13866,7 +14604,7 @@ func referableFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13945,7 +14683,7 @@ func identifiableFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -13996,7 +14734,7 @@ func hasKindFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14043,7 +14781,7 @@ func hasDataSpecificationFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14124,7 +14862,7 @@ func qualifiableFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14199,7 +14937,7 @@ func submodelElementFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14272,7 +15010,7 @@ func relationshipElementFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14321,7 +15059,7 @@ func dataElementFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14378,7 +15116,7 @@ func eventElementFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14425,7 +15163,7 @@ func abstractLangStringFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}
@@ -14480,7 +15218,7 @@ func dataSpecificationContentFromMap(
 	modelTypeAny, ok = m["modelType"]
 	if !ok {
 		err = newDeserializationError(
-			"Expected the property modelType, but got none",
+			"The required property modelType is missing",
 		)
 		return
 	}

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.error
@@ -1,0 +1,1 @@
+assetAdministrationShells[0].modelType: Expected the model type 'AssetAdministrationShell', but got aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.error
@@ -1,0 +1,1 @@
+conceptDescriptions[0].modelType: Expected the model type 'ConceptDescription', but got aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.error
@@ -1,0 +1,1 @@
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Unexpected model type for IDataSpecificationContent: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].modelType: Expected the model type 'Submodel', but got aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.error
@@ -1,0 +1,1 @@
+assetAdministrationShells[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.error
@@ -1,0 +1,1 @@
+conceptDescriptions[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.error
@@ -1,0 +1,1 @@
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.error
+++ b/testdata/DeserializationError/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.error
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: The required property modelType is missing

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
@@ -1,0 +1,12 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
@@ -1,0 +1,30 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "modelType": "aCompletelyInvalidModelType",
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
@@ -1,0 +1,24 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
@@ -1,0 +1,29 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017"
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
+++ b/testdata/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We explicitly check during the JSON de-serialization that model types correspond to the expected model types. We need to be particularly careful with concrete classes without descendants with a mandatory ``modelType``, as they do not necessarily require a model type for de-serialization, but the specs mandate it for reasons of backward compatibility.

The code corresponds to [aas-core-codegen 56482d65], and the test data corresponds to [aas-core3.0-testgen 9e523511c].

This is related to the issue [aas-core3.0-python #32], which discovered the problematic in the first place.

[aas-core-codegen 56482d65]: https://github.com/aas-core-works/aas-core-codegen/commit/56482d65
[aas-core3.0-testgen 9e523511c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9e523511c
[aas-core3.0-python #32]: https://github.com/aas-core-works/aas-core3.0-python/issues/32